### PR TITLE
Fix compiler warnings and missing argument; add nicer LED handling

### DIFF
--- a/Inc/can.h
+++ b/Inc/can.h
@@ -22,6 +22,9 @@ void can_init(void);
 void can_enable(void);
 void can_disable(void);
 void can_set_bitrate(enum can_bitrate bitrate);
+void can_set_silent(uint8_t silent);
 uint32_t can_tx(CanTxMsgTypeDef *tx_msg, uint32_t timeout);
+uint32_t can_rx(CanRxMsgTypeDef *rx_msg, uint32_t timeout);
+uint8_t is_can_msg_pending(uint8_t fifo);
 
 #endif // _CAN_H

--- a/Inc/led.h
+++ b/Inc/led.h
@@ -1,0 +1,10 @@
+#ifndef _LED_H
+#define _LED_H
+
+
+#define LED_DURATION 50
+
+void led_on(void);
+void led_process(void);
+
+#endif

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 BUILD_NUMBER ?= 0
 
 # SOURCES: list of sources in the user application
-SOURCES = main.c usbd_conf.c usbd_cdc_if.c usb_device.c usbd_desc.c stm32f0xx_hal_msp.c stm32f0xx_it.c system_stm32f0xx.c can.c slcan.c
+SOURCES = main.c usbd_conf.c usbd_cdc_if.c usb_device.c usbd_desc.c stm32f0xx_hal_msp.c stm32f0xx_it.c system_stm32f0xx.c can.c slcan.c led.c
 
 # TARGET: name of the user application
 TARGET = CANtact-b$(BUILD_NUMBER)

--- a/Src/can.c
+++ b/Src/can.c
@@ -1,5 +1,6 @@
 #include "stm32f0xx_hal.h"
 #include "can.h"
+#include "led.h"
 
 CAN_HandleTypeDef hcan;
 CAN_FilterConfTypeDef filter;
@@ -113,7 +114,7 @@ uint32_t can_tx(CanTxMsgTypeDef *tx_msg, uint32_t timeout) {
     hcan.pTxMsg = tx_msg;
     status = HAL_CAN_Transmit(&hcan, timeout);
 
-    HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_1);
+	led_on();
     return status;
 }
 
@@ -124,7 +125,7 @@ uint32_t can_rx(CanRxMsgTypeDef *rx_msg, uint32_t timeout) {
 
     status = HAL_CAN_Receive(&hcan, CAN_FIFO0, timeout);
 
-    HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_1);
+	led_on();
     return status;
 }
 

--- a/Src/led.c
+++ b/Src/led.c
@@ -1,0 +1,35 @@
+//
+// LED: Handles blinking of status light
+//
+
+#include "stm32f0xx_hal.h"
+#include "led.h"
+
+static uint32_t led_laston = 0;
+static uint32_t led_lastoff = 0;
+
+// Attempt to turn on status LED
+void led_on(void)
+{
+	// Make sure the LED has been off for at least LED_DURATION before turning on again
+	// This prevents a solid status LED on a busy canbus
+	if(led_laston == 0 && HAL_GetTick() - led_lastoff > LED_DURATION)
+	{
+		HAL_GPIO_WritePin(GPIOB, GPIO_PIN_1, 1);
+		led_laston = HAL_GetTick();
+	}
+}
+
+
+// Process time-based LED events
+void led_process(void)
+{
+	// If LED has been on for long enough, turn it off
+	if(led_laston > 0 && HAL_GetTick() - led_laston > LED_DURATION)
+	{
+		HAL_GPIO_WritePin(GPIOB, GPIO_PIN_1, 0);
+		led_laston = 0;
+		led_lastoff = HAL_GetTick();
+	}
+}
+

--- a/Src/main.c
+++ b/Src/main.c
@@ -42,8 +42,8 @@
 #include "slcan.h"
 #include "led.h"
 
-#define INTERNAL_OSCILLATOR
-//#define EXTERNAL_OSCILLATOR
+//#define INTERNAL_OSCILLATOR
+#define EXTERNAL_OSCILLATOR
 
 /* USER CODE END Includes */
 

--- a/Src/main.c
+++ b/Src/main.c
@@ -114,7 +114,7 @@ int main(void)
 
 
     for (;;) {
-		while (!is_can_msg_pending())
+		while (!is_can_msg_pending(CAN_FIFO0))
 			led_process();
 		status = can_rx(&rx_msg, 3);
 		if (status == HAL_OK) {

--- a/Src/slcan.c
+++ b/Src/slcan.c
@@ -69,11 +69,15 @@ int8_t slcan_parse_str(char *buf, uint8_t len) {
 
     // convert from ASCII (2nd character to end)
     for (i = 1; i < len; i++) {
-        if (buf[i] < 'A') {
-            buf[i] -= 0x30;
-        } else {
-            buf[i] -= 0x37;
-        }
+        // lowercase letters
+        if(buf[i] >= 'a')
+            buf[i] = buf[i] - 'a' + 10;
+        // uppercase letters
+        else if(buf[i] >= 'A')
+            buf[i] = buf[i] - 'A' + 10;
+        // numbers
+        else
+            buf[i] = buf[i] - '0';
     }
 
     if (buf[0] == 'O') {


### PR DESCRIPTION
Due to some missing includes, the code compiled with the call to is_can_msg_pending() despite not having any arguments. The missing includes are now resolved and the correct argument is passed.

I also added an LED handler that turns on the LED when a message is sent or received, turns it off after a set duration of time, and only allows turn-on after the LED has been off for the set duration. This prevents the LED from being solid on high-activity busses.
