### PR TITLE
Generate unique serial codes for the USB device from the ST32 UUID

### DIFF
--- a/Src/usbd_desc.c
+++ b/Src/usbd_desc.c
@@ -228,6 +228,26 @@ uint8_t *  USBD_FS_ManufacturerStrDescriptor( USBD_SpeedTypeDef speed , uint16_t
   return USBD_StrDesc;
 }
 
+#define STM32_UUID ((uint32_t *)0x1FFFF7AC)
+static void IntToAscii (uint32_t value , uint8_t *pbuf , uint8_t len)
+{
+  uint8_t idx = 0;
+
+  for( idx = 0 ; idx < len ; idx ++)
+  {
+    if( ((value >> 28)) < 0xA )
+    {
+      pbuf[ idx ] = (value >> 28) + '0';
+    }
+    else
+    {
+      pbuf[ idx ] = (value >> 28) + 'A' - 10;
+    }
+
+    value = value << 4;
+    pbuf[ idx + 1] = 0;
+  }
+}
 /**
 * @brief  USBD_FS_SerialStrDescriptor
 *         return the serial number string descriptor
@@ -237,14 +257,11 @@ uint8_t *  USBD_FS_ManufacturerStrDescriptor( USBD_SpeedTypeDef speed , uint16_t
 */
 uint8_t *  USBD_FS_SerialStrDescriptor( USBD_SpeedTypeDef speed , uint16_t *length)
 {
-  if(speed  == USBD_SPEED_HIGH)
-  {
-    USBD_GetString (USBD_SERIALNUMBER_STRING_FS, USBD_StrDesc, length);
-  }
-  else
-  {
-    USBD_GetString (USBD_SERIALNUMBER_STRING_FS, USBD_StrDesc, length);
-  }
+  uint8_t s[0x100];
+  IntToAscii(STM32_UUID[0], &s[0], 8);
+  IntToAscii(STM32_UUID[1], &s[8], 8);
+  IntToAscii(STM32_UUID[2], &s[16], 8);
+  USBD_GetString (s, USBD_StrDesc, length);
   return USBD_StrDesc;
 }
 


### PR DESCRIPTION
The UUID address is specific for the stm32f042c6t6 from http://www.eeworld.com.cn/mcu/2015/0825/article_21901.html

This article:
https://techoverflow.net/blog/2015/02/03/reading-the-stm32-unique-device-id-in-c/
seems incorrect. 
