### PR TITLE
Fix USB enumeration-related compile signedness warnings

### DIFF
--- a/Src/usbd_desc.c
+++ b/Src/usbd_desc.c
@@ -65,14 +65,14 @@
     #define CANTACT_SW_VER		"b" STRINGIZE(CANTACT_BUILD_NUMBER)
 #endif
 
-#define USBD_VID			0xad50
-#define USBD_LANGID_STRING		1033
-#define USBD_MANUFACTURER_STRING	"CANtact"
-#define USBD_PID_FS			0x60c4
-#define USBD_PRODUCT_STRING_FS		"CANtact" " " CANTACT_SW_VER
-#define USBD_SERIALNUMBER_STRING_FS     "00000000001A"
-#define USBD_CONFIGURATION_STRING_FS    "CDC Config"
-#define USBD_INTERFACE_STRING_FS	"CDC Interface"
+#define USBD_VID			                      0xad50
+#define USBD_LANGID_STRING		             1033
+#define USBD_MANUFACTURER_STRING	        (uint8_t*)"CANtact"
+#define USBD_PID_FS			                   0x60c4
+#define USBD_PRODUCT_STRING_FS		         (uint8_t*)"CANtact" " " CANTACT_SW_VER
+#define USBD_SERIALNUMBER_STRING_FS      (uint8_t*)"00000000001A"
+#define USBD_CONFIGURATION_STRING_FS     (uint8_t*)"CDC Config"
+#define USBD_INTERFACE_STRING_FS	        (uint8_t*)"CDC Interface"
 
 /**
   * @}


### PR DESCRIPTION
Fixes compilation warnings of the sort (mentioned on https://github.com/linklayer/cantact/issues/3)... quick on-the-web type of patch/PR so tabs and spaces are garbled, but you get the point :-S

```C
arm-none-eabi-gcc -DCORE_M0 -D HSI48_VALUE=48000000 -D HSE_VALUE=16000000 -D CANTACT_BUILD_NUMBER=0 -DSTM32F042x6 -IDrivers/CMSIS/Include -IDrivers/CMSIS/Device/ST/STM32F0xx/Include -IDrivers/STM32F0xx_HAL_Driver/Inc -IInc -IMiddlewares/ST/STM32_USB_Device_Library/Core/Inc -IMiddlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc  -mcpu=cortex-m0 -mthumb -Wall -g -ffunction-sections -fdata-sections -Os -Os -c -o build/usbd_desc.o Src/usbd_desc.c
Src/usbd_desc.c: In function 'USBD_FS_ManufacturerStrDescriptor':
Src/usbd_desc.c:70:34: warning: pointer targets in passing argument 1 of 'USBD_GetString' differ in signedness [-Wpointer-sign]
   70 | #define USBD_MANUFACTURER_STRING "CANtact"
      |                                  ^~~~~~~~~
      |                                  |
      |                                  char *
Src/usbd_desc.c:227:19: note: in expansion of macro 'USBD_MANUFACTURER_STRING'
  227 |   USBD_GetString (USBD_MANUFACTURER_STRING, USBD_StrDesc, length);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from Middlewares/ST/STM32_USB_Device_Library/Core/Inc/usbd_core.h:36,
                 from Src/usbd_desc.c:37:
Middlewares/ST/STM32_USB_Device_Library/Core/Inc/usbd_ctlreq.h:90:39: note: expected 'uint8_t *' {aka 'unsigned char *'} but argument is of type 'char *'
   90 | void USBD_GetString         (uint8_t *desc, uint8_t *unicode, uint16_t *len);
      |                              ~~~~~~~~~^~~~
```